### PR TITLE
Fix slider hover coloring

### DIFF
--- a/libraryroot.custom.css
+++ b/libraryroot.custom.css
@@ -1616,11 +1616,21 @@ button.TextButton[class*="appdetailsfriendssection_ShowMore_"] {
 [class*="gamepadslider_SliderTrack_"] {
     --left-track-color: rgb(var(--focus));
 }
+[class*="gamepadslider_SliderControl_"]:hover [class*="gamepadslider_SliderTrack_"] {
+    --left-track-color: rgb(var(--focus));
+	filter: brightness(1.2);
+}
+[class*="gamepadslider_SliderControl_"] {
+	border-radius: 0;
+}
 [class*="gamepadslider_SliderHandle_"] {
     background: rgb(var(--white));
 }
 [class*="gamepadslider_SliderTrack_"] {
     background: rgb(var(--black));
+}
+[class*="gamepadslider_SliderTrack_"]::before {
+	border-radius: 0;
 }
 button[class*="accountpanel_FatButton_"] [class*="accountpanel_Label_"] {
     color: rgb(var(--white));


### PR DESCRIPTION
Sliders now properly update the color on hover to track the `--focus` they should've been assigned, I also set the corner radius to 0 to make it more in-line with the rest of the skin

Before:
![Screenshot_20231010_111945](https://github.com/RoseTheFlower/MetroSteam/assets/16214950/2e25185b-aaba-4356-85d1-1b75c3405a29)
After:
![Screenshot_20231010_111926](https://github.com/RoseTheFlower/MetroSteam/assets/16214950/bcf7155e-31af-474c-8d53-e111687caf12)

I used orange to highlight the issue, the default focus color is still blue
